### PR TITLE
Update gulp deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/instrumentisto/gulp-bower-builder",
   "dependencies": {
     "extend": "^3.0.0",
-    "gulp": "^3.9.0",
+    "gulp": "^4.0.0",
     "gulp-concat": "^2.6.0",
     "gulp-if": "^2.0.0",
     "gulp-minify-css": "^1.1.6",


### PR DESCRIPTION
As Node 12 don't support gulp 3 anymore, one needs to update gulp dependency